### PR TITLE
INS-2041: Add TSESTREE_SINGLE_RUN to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,6 @@ jobs:
           publish: pnpm changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prevent typescript-eslint from inferring a singleRun on CI to create an isolated TS program with default TS config breaking some tests,
+          # see https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/inferSingleRun.ts#L36
+          TSESTREE_SINGLE_RUN: false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `TSESTREE_SINGLE_RUN: false` in `.github/workflows/release.yml` to stop `@typescript-eslint/typescript-estree` from inferring single-run mode on CI. This avoids the isolated default TS program that broke tests and stabilizes TypeScript ESLint in CI, addressing INS-2041.

<sup>Written for commit 6f01842bb62e1841731ef320005b9c521e5d1846. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

