### PR TITLE
INS-2401: Remove check for changeset status on husky pre-push for changeset commit to work

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,5 +3,3 @@
 set -e
 
 pnpm test
-
-pnpm changeset status


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `pnpm changeset status` from `.husky/pre-push` so pushes aren’t blocked and changeset commits can be pushed (INS-2401). `pnpm test` still runs on pre-push.

<sup>Written for commit 4ff90f3a5e045ed7fa188237b3f7e933a783e918. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

