### PR TITLE
INS-2401: Add node 24 changeset

### DIFF
--- a/.changeset/fancy-memes-smash.md
+++ b/.changeset/fancy-memes-smash.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Update Node version to 24 in GitHub Actions to enable trusted publishing


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a changeset to publish a patch of `eslint-config-opencover` for the Node 24 GitHub Actions upgrade, enabling trusted publishing. Supports INS-2401.

<sup>Written for commit 03ab3543c1a7a83e6626a29997b2d18bfc6804c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

