### PR TITLE
INS-2041: Use npm publish over changeset publish

### DIFF
--- a/.changeset/lovely-bottles-check.md
+++ b/.changeset/lovely-bottles-check.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Use npm publish over changeset publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
           node-version-file: .nvmrc
           cache: 'pnpm'
 
+      - name: 🔎 Show Node and npm versions
+        run: |
+          node -v
+          npm -v
+          pnpm -v
+
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:release": "pnpm build && changeset publish",
+    "changeset:release": "pnpm build && npm publish --access public",
     "prepare": "husky",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the release process to use npm publish instead of changeset publish for `eslint-config-opencover`. Aligns with INS-2041 and ensures packages are published publicly with better CI visibility.

- **Refactors**
  - Update `changeset:release` to run `npm publish --access public` after build.
  - Add CI step to print Node, npm, and pnpm versions in `.github/workflows/release.yml`.
  - Add a patch changeset for `eslint-config-opencover`.

<sup>Written for commit e02ba94ae185c9d69be927fff14b865fd7630650. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

