### PR TITLE
INS-2041: Enable verbose for npm publish

### DIFF
--- a/.changeset/dull-experts-reply.md
+++ b/.changeset/dull-experts-reply.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Enable verbose for npm publish

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenCoverDeFi/eslint-config-opencover.git"
+    "url": "git+https://github.com/OpenCoverDeFi/eslint-config-opencover.git"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:release": "pnpm build && npm publish --access public",
+    "changeset:release": "pnpm build && NODE_AUTH_TOKEN=\"\" npm publish --verbose --access public",
     "prepare": "husky",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable verbose logging for npm publish in the `changeset:release` script to improve release troubleshooting (INS-2041).
Also updates `repository.url` to `git+https` format and adds a patch changeset for `eslint-config-opencover`.

<sup>Written for commit d8c27b6c9cc6bb202a31a8638cbe0b8ff1bc26f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

