### PR TITLE
INS-2041: Enable verbose for npm publish

### DIFF
--- a/.changeset/floppy-crabs-go.md
+++ b/.changeset/floppy-crabs-go.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Use npm auth token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           publish: pnpm changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           # Prevent typescript-eslint from inferring a singleRun on CI to create an isolated TS program with default TS config breaking some tests,
           # see https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/inferSingleRun.ts#L36
           TSESTREE_SINGLE_RUN: false

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:release": "pnpm build && NODE_AUTH_TOKEN=\"\" npm publish --verbose --access public",
+    "changeset:release": "pnpm build && npm publish --verbose --access public",
     "prepare": "husky",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes npm publish in the release workflow by using the `NODE_AUTH_TOKEN` secret and removing the local token override, while keeping verbose logs for easier debugging. Aligns with INS-2041 to ensure reliable `eslint-config-opencover` releases.

- **Bug Fixes**
  - Pass `NODE_AUTH_TOKEN` from GitHub secrets in `.github/workflows/release.yml`.
  - Update `changeset:release` script to stop clearing the token before `npm publish`.

<sup>Written for commit c6fb19ef2dd78eb3308b029c3b63e27fc1557c8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

