### PR TITLE
INS-2041: Fix NPM auth setup

### DIFF
--- a/.changeset/mighty-baboons-matter.md
+++ b/.changeset/mighty-baboons-matter.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Fix npm auth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile
 
+      - name: 🔑 Set npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
       - name: 🚀 Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
@@ -46,7 +51,6 @@ jobs:
           publish: pnpm changeset:release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           # Prevent typescript-eslint from inferring a singleRun on CI to create an isolated TS program with default TS config breaking some tests,
           # see https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/typescript-estree/src/parseSettings/inferSingleRun.ts#L36
           TSESTREE_SINGLE_RUN: false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes npm auth in the release workflow so CI can publish `eslint-config-opencover` reliably. Addresses INS-2041 by writing the token from the `NPM_AUTH_TOKEN` secret to `.npmrc`, removing the previous env usage in the publish step, and adding a patch changeset.

<sup>Written for commit 353528a4e8106c647886f0d4c53ddd55b2500656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

