### PR TITLE
INS-2041: Remove npm auth setup

### DIFF
--- a/.changeset/lucky-adults-smell.md
+++ b/.changeset/lucky-adults-smell.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Remove npm auth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,6 @@ jobs:
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile
 
-      - name: 🔑 Set npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
       - name: 🚀 Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove npm auth setup from the release workflow as part of INS-2041 to simplify CI and rely on existing credentials. Adds a patch changeset for `eslint-config-opencover`.

<sup>Written for commit d9867b5ac0cd9692f530aa48d3163b4b246fb1f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

