### PR TITLE
INS-2401: Use changeset publish

### DIFF
--- a/.changeset/common-pianos-fry.md
+++ b/.changeset/common-pianos-fry.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Use changeset publish over npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,6 @@ jobs:
           node-version-file: .nvmrc
           cache: 'pnpm'
 
-      - name: 🔎 Show Node and npm versions
-        run: |
-          node -v
-          npm -v
-          pnpm -v
-
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:release": "pnpm build && npm publish --verbose --access public",
+    "changeset:release": "pnpm build && changeset publish",
     "prepare": "husky",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the release flow to use Changesets for publishing `eslint-config-opencover`, replacing the manual `npm publish` step. Aligns with INS-2401 and simplifies CI.

- **Refactors**
  - Update `changeset:release` to run `changeset publish` after build.
  - Add a patch changeset documenting the change.
  - Remove the CI step that prints Node/npm/pnpm versions.

<sup>Written for commit 5090441180908b78968729fbb24e6ce0a88bf6be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

