### PR TITLE
INS-2404: Add SHA hashes to GA actions and security:openssf-scorecard preset to renovate.json

### DIFF
--- a/.changeset/chilly-games-pump.md
+++ b/.changeset/chilly-games-pump.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Add SHA to GitHub Actions and simplify renovate bot config with security:openssf-scorecard preset

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      github-actions:
+      all:
         patterns:
           - '*'
     cooldown:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "schedule:weekdays"],
+  "extends": ["config:best-practices", "security:openssf-scorecard", "schedule:weekdays"],
   "enabledManagers": ["npm"],
   "osvVulnerabilityAlerts": true,
   "packageRules": [
@@ -22,13 +22,6 @@
       "minimumReleaseAge": "14 days",
       "automerge": true,
       "enabled": true
-    },
-    {
-      "matchSourceUrls": ["https://github.com/**"],
-      "prBodyColumns": ["Package", "Type", "Update", "Change", "Pending", "OpenSSF"],
-      "prBodyDefinitions": {
-        "OpenSSF": "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})"
-      }
     }
   ],
   "reviewers": ["team:tx"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
       - name: ⎔ Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: 🚀 Create Release Pull Request or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm changeset:version
           publish: pnpm changeset:release


### PR DESCRIPTION
- Add SHA hashes to GA actions
- Add security:openssf-scorecard preset to renovate.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins GitHub Actions to commit SHAs and enables the OpenSSF Scorecard preset in Renovate to harden CI/CD for INS-2404. Adds a patch changeset for `eslint-config-opencover`.

- **Dependencies**
  - Pinned `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, and `changesets/action` to commit SHAs in CI and release workflows.
  - Enabled `security:openssf-scorecard` in Renovate; removed the custom OpenSSF badge PR body rule.
  - Renamed Dependabot group to `all` to group all updates.

<sup>Written for commit f02fe8aea4fa0157d75ef42c361a9cb87087d589. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

