### PR TITLE
INS-2404: Fix rootDir in TS6

### DIFF
--- a/.changeset/easy-canyons-turn.md
+++ b/.changeset/easy-canyons-turn.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Fix rootDir in TypeScript 6

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false
+    "noEmit": false,
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "tests", "dist"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Addresses INS-2404 by setting `rootDir` to `./src` in `tsconfig.build.json` to restore correct emit and declaration paths under TypeScript 6. Adds a changeset to release a patch for `eslint-config-opencover`.

<sup>Written for commit d10dc48a86c48b6b2e5d468bcbc38f493f57138d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

