### PR TITLE
INS-2427: Remove eslint limit from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,9 +34,9 @@
       "addLabels": ["private-package"]
     },
     {
-      "description": "Disable major updates for Node types and ESLint",
+      "description": "Disable major updates for Node types",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node", "eslint"],
+      "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow Renovate to propose major `eslint` upgrades by removing it from the "disable major updates" rule in `.github/renovate.json`. Major updates for `@types/node` remain disabled (INS-2427).

<sup>Written for commit 582d32f28393038b35fb2572e68eb52bb21c83e4. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/74?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

