### PR TITLE
INS-2334: Remove TS 6 default compiler options

### DIFF
--- a/.changeset/wet-steaks-enter.md
+++ b/.changeset/wet-steaks-enter.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Remove TypeScript 6 default compiler options from tsconfig.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "target": "es2024",
     "module": "nodenext",
-    "strict": true,
-    "esModuleInterop": true,
     "noEmit": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- Remove TypeScript 6 default compiler options from tsconfig
- Keep project-specific compiler options explicit

## Validation
- Commit hooks ran typecheck/lint-staged during commit
- Pre-push hooks ran repository tests where configured

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant TypeScript 6 defaults from `tsconfig.json` by deleting `strict` and `esModuleInterop`, relying on TS 6 defaults and keeping only project-specific options. Added a changeset to publish a patch for `eslint-config-opencover` per INS-2334.

<sup>Written for commit 9c4fbb55a9252c9bc3a7ebcf87960ac59c8c4fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

