### PR TITLE
INS-2593: Support Next.js dynamic route filenames

### DIFF
--- a/.changeset/friendly-nextjs-routes.md
+++ b/.changeset/friendly-nextjs-routes.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Allow files below Next.js App Router dynamic route directories to use the framework's parameter naming conventions.

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ Later matching config objects override earlier ones for those files.
 
 Available config names:
 
-| Name                   | Description                          |
-| ---------------------- | ------------------------------------ |
-| `opencover`            | Base rules (stylistic, imports, etc) |
-| `opencover/gitignore`  | Ignores files from `.gitignore`      |
-| `opencover/typescript` | TypeScript-specific rules            |
-| `opencover/test`       | Test file rules (vitest)             |
-| `opencover/react`      | React-specific TSX rules             |
+| Name                             | Description                                  |
+| -------------------------------- | -------------------------------------------- |
+| `opencover`                      | Base rules (stylistic, imports, etc)         |
+| `opencover/gitignore`            | Ignores files from `.gitignore`              |
+| `opencover/nextjs-dynamic-route` | Allows Next.js dynamic route directory names |
+| `opencover/typescript`           | TypeScript-specific rules                    |
+| `opencover/test`                 | Test file rules (vitest)                     |
+| `opencover/react`                | React-specific TSX rules                     |

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,13 @@ const config: Linter.Config[] = [
         },
     },
     {
+        name: 'opencover/nextjs-dynamic-route',
+        files: ['{app,src/app}/**/[[]*[]]/**/*.{js,jsx,ts,tsx}'],
+        rules: {
+            'unicorn/filename-case': 'off',
+        },
+    },
+    {
         name: 'opencover/typescript',
         files: GLOB_TS,
         languageOptions: {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -48,6 +48,7 @@ describe('opencover preset', () => {
 
         expect(names).toContain('opencover');
         expect(names).toContain('opencover/gitignore');
+        expect(names).toContain('opencover/nextjs-dynamic-route');
         expect(names).toContain('opencover/typescript');
         expect(names).toContain('opencover/test');
     });

--- a/tests/lint.ts
+++ b/tests/lint.ts
@@ -14,6 +14,16 @@ const config: Linter.Config = {
 const linter = new ESLint({ overrideConfig: config });
 const fixer = new ESLint({ fix: true, overrideConfig: config });
 
+type CalculatedConfig = {
+    rules?: Linter.RulesRecord;
+};
+
+export async function calculateConfig(filePath: string): Promise<CalculatedConfig | undefined> {
+    const calculatedConfig: unknown = await linter.calculateConfigForFile(filePath);
+
+    return calculatedConfig as CalculatedConfig | undefined;
+}
+
 export async function lint(code: string, filePath: string): Promise<ESLint.LintResult[]> {
     return linter.lintText(code, { filePath });
 }

--- a/tests/unicorn.test.ts
+++ b/tests/unicorn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lint } from './lint.js';
+import { calculateConfig, lint } from './lint.js';
 
 describe('unicorn', () => {
     describe('unicorn/no-array-callback-reference', () => {
@@ -49,6 +49,33 @@ describe('unicorn', () => {
             results.forEach((result) => {
                 expect(result.messages.filter((m) => m.ruleId === 'unicorn/filename-case')).toHaveLength(1);
             });
+        });
+
+        it.each(['js', 'jsx', 'ts', 'tsx'])(
+            'allows .%s files in Next.js dynamic route directories',
+            async (extension) => {
+                const config = await calculateConfig(`src/app/proof-of-cover/[requestId]/page.${extension}`);
+
+                expect(config?.rules?.['unicorn/filename-case']).toEqual([0]);
+            }
+        );
+
+        it.each(['[...requestIds]', '[[...requestIds]]'])('allows Next.js %s route directories', async (directory) => {
+            const config = await calculateConfig(`app/proof-of-cover/${directory}/page.tsx`);
+
+            expect(config?.rules?.['unicorn/filename-case']).toEqual([0]);
+        });
+
+        it('still bans camel-case static route directories', async () => {
+            const config = await calculateConfig('src/app/proofOfCover/page.tsx');
+
+            expect(config?.rules?.['unicorn/filename-case']).toEqual([2]);
+        });
+
+        it('still bans PascalCase filenames in static route directories', async () => {
+            const config = await calculateConfig('src/app/proof-of-cover/MyComponent.tsx');
+
+            expect(config?.rules?.['unicorn/filename-case']).toEqual([2]);
         });
     });
 


### PR DESCRIPTION
## Summary
- allow files below Next.js App Router dynamic route directories
- preserve filename enforcement for static routes
- cover JavaScript, JSX, TypeScript, TSX, catch-all, and optional catch-all routes
- add a patch changeset

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Next.js App Router dynamic route directories in `eslint-config-opencover` (INS-2593). Files under `[param]`, `[...param]`, and `[[...param]]` now skip `unicorn/filename-case`; static routes keep filename rules.

- **New Features**
  - New `opencover/nextjs-dynamic-route` config disables `unicorn/filename-case` for files in dynamic route folders under `app/` and `src/app/` (`.js`, `.jsx`, `.ts`, `.tsx`).
  - Tests cover dynamic, catch-all, and optional catch-all routes; README updated; patch changeset added.

<sup>Written for commit ae40aa17d475ffffc2169da94a6dd6c67930b346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

