### PR TITLE
INS-2593: Preserve conventional abbreviations

### DIFF
--- a/.changeset/calm-name-replacements.md
+++ b/.changeset/calm-name-replacements.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Keep conventional abbreviations allowed after Unicorn renamed `prevent-abbreviations` to `name-replacements`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ const config: Linter.Config[] = [
             ],
             'import-x/no-unresolved': 'off',
 
-            'unicorn/prevent-abbreviations': 'off',
+            'unicorn/name-replacements': 'off',
             'unicorn/consistent-class-member-order': 'off',
             'unicorn/no-array-for-each': 'off',
             'unicorn/no-for-each': 'off',

--- a/tests/unicorn.test.ts
+++ b/tests/unicorn.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { calculateConfig, lint } from './lint.js';
 
 describe('unicorn', () => {
+    describe('unicorn/name-replacements', () => {
+        it('allows conventional abbreviations', async () => {
+            const results = await lint('type ButtonProps = { ref: string };', 'file.ts');
+
+            results.forEach((result) => {
+                expect(result.messages.filter((m) => m.ruleId === 'unicorn/name-replacements')).toHaveLength(0);
+            });
+        });
+    });
+
     describe('unicorn/no-array-callback-reference', () => {
         it('allows inline arrow functions', async () => {
             const results = await lint('const result = arr.filter((x) => isValid(x));', 'file.ts');


### PR DESCRIPTION
## Summary
- update the OpenCover override for Unicorn 70
- keep conventional `Props`, `ref`, and similar abbreviations allowed
- add regression coverage and a patch changeset

## Context
`unicorn/prevent-abbreviations` was renamed to `unicorn/name-replacements` in Unicorn 70.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `eslint-config-opencover` for `eslint-plugin-unicorn` v70 (INS-2593). Switch from `unicorn/prevent-abbreviations` to `unicorn/name-replacements` while keeping abbreviations like `Props` and `ref` allowed.

- **Bug Fixes**
  - Disable `unicorn/name-replacements` to preserve previous behavior.
  - Add regression test for `Props`/`ref`.
  - Add patch changeset for `eslint-config-opencover`.

<sup>Written for commit 63c854c9104f5394e17e6fedcae2e74931ac3f89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

