### PR TITLE
ENG-7: Support Next.js dynamic routes in package workspaces

### DIFF
--- a/.changeset/nextjs-package-workspaces.md
+++ b/.changeset/nextjs-package-workspaces.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-opencover': patch
+---
+
+Support Next.js dynamic route directories inside one-level `packages/*` workspaces.

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,10 @@ const config: Linter.Config[] = [
     },
     {
         name: 'opencover/nextjs-dynamic-route',
-        files: ['{app,src/app}/**/[[]*[]]/**/*.{js,jsx,ts,tsx}'],
+        files: [
+            '{app,src/app}/**/[[]*[]]/**/*.{js,jsx,ts,tsx}',
+            'packages/*/{app,src/app}/**/[[]*[]]/**/*.{js,jsx,ts,tsx}',
+        ],
         rules: {
             'unicorn/filename-case': 'off',
         },

--- a/tests/unicorn.test.ts
+++ b/tests/unicorn.test.ts
@@ -75,6 +75,22 @@ describe('unicorn', () => {
             expect(config?.rules?.['unicorn/filename-case']).toEqual([0]);
         });
 
+        it.each([
+            'packages/api/src/app/api/[...slug]/route.ts',
+            'packages/app/src/app/alerts/[workspaceId]/page.tsx',
+            'packages/admin/app/users/[[...userIds]]/page.tsx',
+        ])('allows Next.js dynamic route directories in package workspaces: %s', async (file) => {
+            const config = await calculateConfig(file);
+
+            expect(config?.rules?.['unicorn/filename-case']).toEqual([0]);
+        });
+
+        it('does not treat other workspace roots as Next.js package workspaces', async () => {
+            const config = await calculateConfig('services/api/src/app/api/[...slug]/route.ts');
+
+            expect(config?.rules?.['unicorn/filename-case']).toEqual([2]);
+        });
+
         it('still bans camel-case static route directories', async () => {
             const results = await lint('export {};', 'src/app/proofOfCover/page.js');
 


### PR DESCRIPTION
## Summary
- preserve root-level `app` and `src/app` dynamic-route support
- add bounded `packages/*/{app,src/app}` support for monorepos
- verify API/frontend package paths and reject unrelated workspace roots
- add a patch changeset

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

Linear: https://linear.app/opencover/issue/ENG-7/support-nextjs-dynamic-routes-in-package-workspaces
Downstream: https://github.com/OpenCoverDeFi/tx-cms/pull/84

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for Next.js dynamic routes inside one-level `packages/*/{app,src/app}` workspaces in `eslint-config-opencover`. Preserves root-level support and rejects unrelated roots (e.g., `services/*`); satisfies Linear ENG-7.

<sup>Written for commit 5293d1815d4d65467008facbc74191c64d4a666f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

