### PR TITLE
ENG-12: Restrict ESLint CI workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: blacksmith-2vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary

- Restrict the CI workflow `GITHUB_TOKEN` to `contents: read`.
- Leave the npm trusted-publishing release permissions unchanged.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (82 tests)
- Prettier and workflow YAML parsing
- Greptile and Cubic reviews

Linear: [ENG-12](https://linear.app/opencover/issue/ENG-12/restrict-eslint-ci-workflow-token-permissions)
