### PR TITLE
ENG-27: Normalize GitHub Action version comments across project repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- change 2 pinned `actions/checkout` version comments from `v7` to the exact `v7.0.0` release
- keep the immutable commit SHA unchanged

## Why

The pinned commit is the `v7.0.0` release. Renovate uses the version comment as the tag to follow, so recording the exact release prevents the comment from drifting behind a movable major alias and lets future version updates advance the comment and SHA together.

## Validation

- parsed all workflow YAML successfully
- verified every external action reference remains pinned to a full commit SHA and has a `major.minor.patch` comment
- `git diff --check`

Linear: [ENG-27](https://linear.app/opencover/issue/ENG-27/normalize-github-action-version-comments-across-project-repositories)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized `actions/checkout` version comments from `v7` to `v7.0.0` in CI and release workflows, keeping the pinned commit SHA the same. This fulfills Linear ENG-27 and lets Renovate track the exact release so the comment and SHA update together.

<sup>Written for commit 7fb7c519e5eda0dce85f98d8e273e986172315fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

