### PR TITLE
ENG-61: Exclude Renovate lockfile maintenance from minimum release age

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,12 @@
       "addLabels": ["private-package"]
     },
     {
+      "description": "Disable minimum release age for npm lockfile maintenance",
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Disable major updates for Node types",
       "matchManagers": ["npm"],
       "matchPackageNames": ["@types/node"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,7 @@
     },
     {
       "description": "Disable minimum release age for npm lockfile maintenance",
-      "matchDatasources": ["npm"],
+      "matchManagers": ["npm"],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "minimumReleaseAge": null
     },


### PR DESCRIPTION
## Summary

- Exclude npm lockfile maintenance from Renovate minimum-release-age checks.
- Keep the global 14-day delay for ordinary dependency updates.
- Existing pnpm native 14-day release-age enforcement remains unchanged.

## Why

Renovate cannot evaluate release timestamps for lockfile maintenance because the package manager chooses transitive updates. The global gate therefore leaves valid lockfile PRs indefinitely pending on `renovate/stability-days`.

## Verification

- `renovate-config-validator --strict --no-global .github/renovate.json`
- JSON parsing and focused rule assertions
- `git diff --check`

[ENG-61](https://linear.app/opencover/issue/ENG-61/exclude-renovate-lockfile-maintenance-from-minimum-release-age)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `npm` `lockFileMaintenance` PRs from Renovate minimum release age so they no longer stall on `renovate/stability-days`, addressing ENG-61. The 14-day delay still applies to other updates, and `pnpm` native release-age rules are unchanged.

<sup>Written for commit 58d22fcd8e1c6b5d5a403981b6fadf0044873713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

