### PR TITLE
Add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: 🔍 Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime, development, unknown
+          show-patched-versions: true


### PR DESCRIPTION
## What changed

- add a pull-request dependency review workflow
- fail when a PR introduces a high or critical vulnerability in runtime, development, or unknown scope
- show the first patched version in the check summary

## Why

This is an isolated experiment to see how GitHub's dependency review represents vulnerable changes before considering wider use. The workflow has read-only repository permissions and uses the current action release pinned to its commit SHA.

A separate stacked draft PR will deliberately introduce a known vulnerable development dependency to prove the failure path without putting that dependency or this workflow on `main`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check .github/workflows/dependency-review.yml`
- pre-commit typecheck
- 82 Vitest tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dependency review workflow on pull requests to block risky dependency changes. It fails the check if a PR adds a high or critical vulnerability in runtime, development, or unknown scopes, and shows the first patched version.

<sup>Written for commit cae7a52621a2a625162e5aad51eb5cdee9987936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

