### PR TITLE
Test dependency review with a vulnerable package

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.7.0",
+    "fast-uri": "3.1.2",
     "husky": "9.1.7",
     "jiti": "2.7.0",
     "knip": "6.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       eslint:
         specifier: 10.7.0
         version: 10.7.0(jiti@2.7.0)
+      fast-uri:
+        specifier: 3.1.2
+        version: 3.1.2
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -1560,6 +1563,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4395,6 +4401,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:

--- a/tests/dependency-review-fixture.test.ts
+++ b/tests/dependency-review-fixture.test.ts
@@ -1,0 +1,6 @@
+import { parse } from 'fast-uri';
+import { expect, it } from 'vitest';
+
+it('loads the deliberately vulnerable dependency-review fixture', () => {
+    expect(parse('https://example.com').host).toBe('example.com');
+});


### PR DESCRIPTION
## Experiment

This stacked draft PR deliberately adds `fast-uri@3.1.2` as a development dependency. That version is affected by two current high-severity advisories (`GHSA-v2hh-gcrm-f6hx` and `GHSA-4c8g-83qw-93j6`). The small test keeps the normal lint, typecheck, Knip, and Vitest pipeline green, isolating the dependency-review result.

This PR must never be merged. It targets the workflow branch rather than `main`, so neither the vulnerable dependency nor the experimental workflow reaches the default branch during the test.

## Expected result

The Dependency Review check should fail and report the introduced development dependency, both high-severity advisories, and their patched versions.

## Local validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test` (83 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Intentionally adds the vulnerable dev dependency `fast-uri@3.1.2` plus a tiny test to trigger and verify the Dependency Review check. Targets the workflow branch only; do not merge to main.

- **Dependencies**
  - Added `fast-uri@3.1.2` (known issues: GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6) to force a failing Dependency Review.
  - Added a small test that imports `fast-uri` so other CI checks stay green while Dependency Review fails.

<sup>Written for commit 3b7403966a994e6aa53dce5dff377b0446572922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

