### PR TITLE
ENG-81: Add dependency review checks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: 🔍 Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime, development, unknown
+          show-patched-versions: true


### PR DESCRIPTION
## What changed

- add a pull-request dependency review workflow
- fail when a PR introduces a high or critical vulnerability in runtime, development, or unknown scope
- show the first patched version in the check summary

## Why

This prevents newly introduced vulnerable dependencies from reaching `main`. The workflow uses read-only repository permissions and pins the current dependency-review action release to its immutable commit SHA.

The failure path was proven in the disposable stacked experiment [#165](https://github.com/OpenCoverDeFi/eslint-config-opencover/pull/165), which deliberately added `fast-uri@3.1.2`. Dependency Review reported both high-severity advisories and failed as expected.

No Changeset is included because this changes repository CI only; it does not change or publish the `eslint-config-opencover` package.

Linear: [ENG-81](https://linear.app/opencover/issue/ENG-81/eslint-config-opencover-add-dependency-review-checks)

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check .github/workflows/dependency-review.yml`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test` (82 tests)
- pre-commit typecheck and formatting
- pre-push test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Dependency Review check on pull requests to block high/critical vulnerable dependency changes across runtime, development, and unknown scopes, and show the first patched version. Implements Linear ENG-81 for `eslint-config-opencover`, using read-only repo permissions and pinning `actions/checkout` and `actions/dependency-review-action` to SHAs for CI hardening.

<sup>Written for commit cb859bfcae711f06fd60c7930899b885f12ea692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenCoverDeFi/eslint-config-opencover/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

